### PR TITLE
bug: declare toolchain deps as inputs for SassMultiCompile action

### DIFF
--- a/sass/defs.bzl
+++ b/sass/defs.bzl
@@ -285,7 +285,7 @@ def _multi_sass_binary_impl(ctx):
 
     if inputs:
         ctx.actions.run(
-            inputs = inputs,
+            inputs = depset(inputs, transitive = [toolchain.deps.files]),
             outputs = outputs,
             arguments = [args],
             executable = sass.files_to_run,


### PR DESCRIPTION
Similar to https://github.com/GZGavinZhao/gzgz_rules_sass/pull/2, this PR fixes RBE failures when using the `multi_sass_binary` rule due to not declaring toolchain dependencies as the action's inputs. 

(to be specific, `sass` would fail to find `dart` at build time)