### PR TITLE
chore: update deprecated platform target

### DIFF
--- a/sass/repositories.bzl
+++ b/sass/repositories.bzl
@@ -75,7 +75,7 @@ filegroup(
 sass_toolchain(
     name = "sass_toolchain",
     sass = select({
-        "@bazel_tools//src/conditions:host_windows": "sass.bat",
+        "@platforms//os:windows": "sass.bat",
         "//conditions:default": "sass",
     }),
     deps = ":sass_deps",


### PR DESCRIPTION
Silences this deprecation warning: 

`WARNING: <output-root>/external/gzgz_rules_sass++sass+sass_x86_64-unknown-linux/BUILD.bazel:9:15: in sass_toolchain rule @@gzgz_rules_sass++sass+sass_x86_64-unknown-linux//:sass_toolchain: target '@@gzgz_rules_sass++sass+sass_x86_64-unknown-linux//:sass_toolchain' depends on deprecated target '@@bazel_tools//src/conditions:host_windows_x64_constraint': No longer used by Bazel and will be removed in the future. Migrate to toolchains or define your own version of this setting.`
